### PR TITLE
allow add Header for webpage check, like 'Host:www.abc.com'; 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 	<li>Platform independent</li>
 	<li>Can run standalone (also as a Windows Service) or on your custom Java EE server and your database</li>
 	<li>Monitor single web page, pages in sitemap and even your whole web site using spider</li>
-	<li>Check not only HTTP result codes, but also page contents</li>
+	<li>Check not only HTTP result codes, but also page contents; Can specify HTTP header for web page request;</li>
 	<li>Find broken links on your website</li>
 	<li>Microservice (REST APIs) monitoring - XML (using XPath and XSD) and JSON (using JSONPath)</li>
 	<li>Periodic checking (built-in cron mechanism)</li>

--- a/src/main/java/net/sf/sitemonitoring/entity/Check.java
+++ b/src/main/java/net/sf/sitemonitoring/entity/Check.java
@@ -1,32 +1,16 @@
 package net.sf.sitemonitoring.entity;
 
-import java.io.Serializable;
-import java.util.Date;
-import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.OrderBy;
-import javax.persistence.Table;
-import javax.persistence.Transient;
+import javax.persistence.*;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Size;
-
-import lombok.Getter;
-import lombok.Setter;
-
-import org.hibernate.validator.constraints.URL;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
 
 @Getter
 @Setter
@@ -87,6 +71,9 @@ public class Check implements Serializable {
 
 	@Size(min = 1, message = "Name cannot be empty!")
 	private String name;
+
+    @Column(nullable = true)
+    private String header;
 
 	@Column(nullable = false)
 	private boolean active;

--- a/src/main/java/net/sf/sitemonitoring/service/check/AbstractSingleCheckThread.java
+++ b/src/main/java/net/sf/sitemonitoring/service/check/AbstractSingleCheckThread.java
@@ -9,8 +9,8 @@ import javax.net.ssl.SSLHandshakeException;
 import lombok.extern.slf4j.Slf4j;
 import net.sf.sitemonitoring.entity.Check;
 
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
+import org.apache.commons.codec.binary.StringUtils;
+import org.apache.http.*;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.config.RequestConfig.Builder;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -91,6 +91,15 @@ public abstract class AbstractSingleCheckThread extends AbstractCheckThread {
 		}
 		RequestConfig requestConfig = requestConfigBuilder.build();
 		request.setConfig(requestConfig);
+        String header = check.getHeader();
+
+        if(null!=header && header.length()>0 && header.contains(":"))
+        {
+            log.info("header:" + header);
+            String[] headerKV = header.split(":");
+            request.setHeader(headerKV[0],headerKV[1]);
+        }
+
 		CloseableHttpResponse response = null;
 		try {
 			request.setHeader("User-Agent", check.getUserAgent());

--- a/src/main/webapp/resources/components/dialog-single-check.xhtml
+++ b/src/main/webapp/resources/components/dialog-single-check.xhtml
@@ -28,6 +28,9 @@
 				url:
 				<p:inputText value="#{checkController.check.url}" style="width:100%" />
 				
+				header:
+				<p:inputText value="#{checkController.check.header}" style="width:100%" />
+				
 				<style>
 					.firstColumn {
 						width:50px;


### PR DESCRIPTION
Sometimes I need to monitor pages behind a load balancer which need 'Host:xxxxx' in the request.
For example, when I have an nginx Load Balancer which is backed by 8 IIS service. In each IIS Server, it binds to several different host on the same port. And I want to monitor every IIS. So I hope to monitor the page like the equivalent request:
curl -H  'Host: www.abc.com' http://192.168.8.9/